### PR TITLE
🛠️ ci: update GitHub Actions to use master branch instead of production

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build check
 on:
     push:
         branches:
-            - production
+            - master
 
 jobs: 
     build:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          ref: production
+          ref: master
 
       - name: Upload JSON schema files to release
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
- change branch reference in build.yml from production to master
- change checkout ref in publish.yml from production to master